### PR TITLE
Foundation 6 dropped modernizr

### DIFF
--- a/app/views/layouts/moneris_simulator/application.html.erb
+++ b/app/views/layouts/moneris_simulator/application.html.erb
@@ -2,7 +2,6 @@
   <head>
     <%= stylesheet_link_tag    "moneris_simulator", media: "all" %>
     <%= javascript_include_tag "moneris_simulator" %>
-    <%= javascript_include_tag "vendor/modernizr" %>
     <%= csrf_meta_tags %>
   </head>
   <body>

--- a/lib/moneris_simulator/version.rb
+++ b/lib/moneris_simulator/version.rb
@@ -1,3 +1,3 @@
 module MonerisSimulator
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
 and we are updating all apps to Foundation 6, so we'll drop the reference here.

🐘 
