### PR TITLE
Fix AutoPrefixer Deprecation

### DIFF
--- a/app/assets/stylesheets/moneris_simulator/inputs.scss
+++ b/app/assets/stylesheets/moneris_simulator/inputs.scss
@@ -62,7 +62,7 @@ body{
   text-transform: none;
   transition-delay: 0s, 0s;
   transition-duration: 0.45s, 0.45s;
-  transition-property: box-shadow, border-color;
+  transition: box-shadow, border-color;
   transition-timing-function: ease, ease-in-out;
   width: 100%;
   word-spacing: 0px;

--- a/lib/moneris_simulator/version.rb
+++ b/lib/moneris_simulator/version.rb
@@ -1,3 +1,3 @@
 module MonerisSimulator
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
:elephant:

* Autoprefixer was complaining on this gem with the following
  warning:
```
autoprefixer: bundle/ruby/2.3.0/gems/moneris_simulator-0.3.0/app/
assets/stylesheets/moneris_simulator/index.scss:66:3:
Replace transition-property to transition, because Autoprefixer could
not support any cases of transition-property and other transition-*
```
* Fix the warning by changing the `transition-property` attribute
  to a basic `transition`.